### PR TITLE
Fix image path in ImageFolderAdapter.iter_data

### DIFF
--- a/src/main/python/gulpio/adapters.py
+++ b/src/main/python/gulpio/adapters.py
@@ -310,8 +310,7 @@ class ImageFolderAdapter(AbstractDatasetAdapter):
     def iter_data(self, slice_element=None):
         slice_element = slice_element or slice(0, len(self))
         for meta in self.all_meta[slice_element]:
-            img_path = os.path.join(self.folder, str(meta['path']),
-                                    str(meta['id']))
+            img_path = os.path.join(str(meta['path']), str(meta['id']))
             img = resize_by_short_edge(img_path, self.img_size)
             result = {'meta': meta,
                       'frames': [img],


### PR DESCRIPTION
`gulp_image_folder` in [this example](https://github.com/TwentyBN/GulpIO/blob/master/examples/GulpIOTrainingExample.ipynb) doesn't work due to `ImageFolderAdapter.iter_data` generates wrong path of image file.

For example, when `self.folder` is `mnist_png/testing`, then `meta['path']` is such as `mnist_png/testing/0` and `img_path` will be `mnist_png/testing/mnist_png/testing/0/*.png`, although the actual path is `mnist_png/testing/0/*.png`.