### PR TITLE
Adaptor and executable script for gulping WEBM videos 

### DIFF
--- a/src/main/python/gulpio/adapters.py
+++ b/src/main/python/gulpio/adapters.py
@@ -167,7 +167,10 @@ class Custom20BNCsvWebmAdapter(AbstractDatasetAdapter,
             content = csv.reader(f, delimiter=';')
             data = []
             for row in content:
-                data.append({'id': row[0], 'label': row[1]})
+                if len(row) == 1:  # For test case
+                    data.append({'id': row[0], 'label': "dummy"})
+                else:  # For train and validation case
+                    data.append({'id': row[0], 'label': row[1]})
         return data
 
     def get_meta(self):

--- a/src/main/scripts/gulp_20bn_csv_webm
+++ b/src/main/scripts/gulp_20bn_csv_webm
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+"""gulp_20bn_json_videos
+
+Gulp a 20bn dataset that is specified using a JSON format and where the input
+data are video files.
+
+Usage:
+    gulp_20bn_json_videos [--videos_per_chunk <videos_per_chunk>]
+                          [--num_workers <num_workers>]
+                          [--frame_size <frame_size>]
+                          [--frame_rate <frame_rate>]
+                          [--shuffle]
+                          [--extend]
+                          [--shm_dir <shm_dir>]
+                          [--label_name <label_name>]
+                          [--remove_duplicates]
+                          <input_csv> <videos_directory> <output_directory>
+    gulp_20bn_json_videos (-h | --help)
+    gulp_20bn_json_videos --version
+
+Arguments:
+    input_csv:                              Input CSV file
+    videos_directory:                       Base directory for video files
+    output_directory:                       Output directory for GulpIO files
+
+Options:
+    -h --help                               Show this screen.
+    --version                               Show version.
+    --videos_per_chunk=<videos_per_chunk>   Number of videos in one chunk [default: 100]
+    --num_workers=<num_workers>             Number of parallel processes [default: 4]
+    --frame_size=<frame_size>               Size of smaller edge of resized frames [default: -1]
+    --frame_rate=<frame_rate>               Frame rate when bursting videos [default: 8]
+    --shuffle                               Shuffle the dataset before ingestion
+    --extend                                Extend Gulps by further files
+    --shm_dir=<shm_dir>                     Temporary directory for bursting frames [default: /dev/shm]
+    --label_name=<label_name>               Key of the label in the json meta data [default: label]
+    --remove_duplicates                     Removes duplicates in json file and entries that are already in GulpDirectory
+"""
+
+from docopt import docopt
+
+from gulpio.adapters import Custom20BNCsvWebmAdapter
+from gulpio.fileio import GulpIngestor
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+    print(arguments)
+
+    input_csv = arguments['<input_csv>']
+    videos_path = arguments['<videos_directory>']
+    output_folder = arguments['<output_directory>']
+    videos_per_chunk = int(arguments['--videos_per_chunk'])
+    num_workers = int(arguments['--num_workers'])
+    frame_size = int(arguments['--frame_size'])
+    frame_rate = int(arguments['--frame_rate'])
+    shuffle = arguments['--shuffle']
+    shm_dir = arguments['--shm_dir']
+    label_name = arguments['--label_name']
+    remove_duplicates = arguments['--remove_duplicates']
+
+    adapter = Custom20BNCsvWebmAdapter(input_csv,
+                                       videos_path,
+                                       output_folder,
+                                       shuffle=shuffle,
+                                       frame_size=frame_size,
+                                       frame_rate=frame_rate,
+                                       shm_dir_path=shm_dir,
+                                       label_name=label_name,
+                                       remove_duplicate_ids=remove_duplicates,
+                                       )
+    ingestor = GulpIngestor(adapter,
+                            output_folder,
+                            videos_per_chunk,
+                            num_workers)
+    ingestor()


### PR DESCRIPTION
This branch:
- Adds an Adaptor for gulping .`webm` videos with annotations contained in `.csv` format
- useful for `smth-smth-baseline` repo release
- tried and tested

Let me know your thoughts.
A lot of repetitions though !