### PR TITLE
Optimise GulpChunk instantiation

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = *_tests.py

--- a/src/main/python/gulpio/dataset.py
+++ b/src/main/python/gulpio/dataset.py
@@ -5,7 +5,7 @@ from .fileio import GulpDirectory
 
 
 class GulpIOEmptyFolder(Exception):  # pragma: no cover
-        pass
+    pass
 
 
 class GulpVideoDataset(object):

--- a/src/main/python/gulpio/fileio.py
+++ b/src/main/python/gulpio/fileio.py
@@ -97,8 +97,8 @@ class GulpDirectory(object):
         self.all_meta_dicts = [c.meta_dict for c in self.chunk_objs_lookup.values()]
         self.num_chunks = len(self.chunk_objs_lookup)
         self.chunk_lookup = {}
-        for chunk_id, meta_dict in zip(self._chunk_ids(), self.all_meta_dicts):
-            for id_ in meta_dict:
+        for chunk_id, chunk in self.chunk_objs_lookup.items():
+            for id_ in chunk.meta_dict:
                 self.chunk_lookup[id_] = chunk_id
         self.merged_meta_dict = {}
         for d in self.all_meta_dicts:

--- a/src/main/python/gulpio/fileio.py
+++ b/src/main/python/gulpio/fileio.py
@@ -92,8 +92,7 @@ class GulpDirectory(object):
 
     def __init__(self, output_dir):
         self.output_dir = output_dir
-        self.chunk_objs_lookup = OrderedDict({chunk_id: chunk for chunk_id, chunk in
-                                              zip(self._chunk_ids(), self._chunks())})
+        self.chunk_objs_lookup = OrderedDict(zip(self._chunk_ids(), self._chunks()))
         self.all_meta_dicts = [c.meta_dict for c in self.chunk_objs_lookup.values()]
         self.num_chunks = len(self.chunk_objs_lookup)
         self.chunk_lookup = {}


### PR DESCRIPTION
Constructing GulpChunks is very expensive and was consuming ~40% of the time spent data loading on of my projects. I've cached the creation of the GulpChunks so they are only initialised once.


