### PR TITLE
Switch np.fromstring to np.frombuffer

### DIFF
--- a/src/main/python/gulpio/fileio.py
+++ b/src/main/python/gulpio/fileio.py
@@ -329,7 +329,7 @@ class GulpChunk(object):
             self.fp.seek(frame_info.loc)
             record = self.fp.read(frame_info.length)
             img_str = record[:len(record)-frame_info.pad]
-            nparr = np.fromstring(img_str, np.uint8)
+            nparr = np.frombuffer(img_str, np.uint8)
             img = cv2.imdecode(nparr, cv2.IMREAD_ANYCOLOR)
             if img.ndim > 2:
                 img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)


### PR DESCRIPTION
Using `np.fromstring` is deprecated on binary buffers, the numpy docs
instruct you to use `np.frombuffer` instead.

This resolves warnings of the form:

    .../site-packages/gulpio/fileio.py:332: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
    nparr = np.fromstring(img_str, np.uint8